### PR TITLE
Enhance schema validation for byte-formatted strings

### DIFF
--- a/src/schemas/audio-content.ts
+++ b/src/schemas/audio-content.ts
@@ -10,7 +10,7 @@ export const audioContentSchema = z.object({
   /**
    * The base64-encoded audio data.
    */
-  data: z.string(),
+  data: z.string().base64(),
   /**
    * The MIME type of the audio. Different providers may support different audio types.
    */

--- a/src/schemas/blob-resource-contents.ts
+++ b/src/schemas/blob-resource-contents.ts
@@ -9,5 +9,5 @@ export const blobResourceContentsSchema = resourceContentsSchema.extend({
   /**
    * A base64-encoded string representing the binary data of the item.
    */
-  blob: z.string(),
+  blob: z.string().base64(),
 }) satisfies ZodType<BlobResourceContents>;

--- a/src/schemas/image-content.ts
+++ b/src/schemas/image-content.ts
@@ -10,7 +10,7 @@ export const imageContentSchema = z.object({
   /**
    * The base64-encoded image data.
    */
-  data: z.string(),
+  data: z.string().base64(),
   /**
    * The MIME type of the image. Different providers may support different image types.
    */


### PR DESCRIPTION
I've updated the Zod schemas for ImageContent, AudioContent, and BlobResourceContents to enforce base64 validation for fields annotated with `@format byte`.

- In `src/schemas/image-content.ts`, I changed `data: z.string()` to `data: z.string().base64()` in `imageContentSchema`.
- In `src/schemas/audio-content.ts`, I changed `data: z.string()` to `data: z.string().base64()` in `audioContentSchema`.
- In `src/schemas/blob-resource-contents.ts`, I changed `blob: z.string()` to `blob: z.string().base64()` in `blobResourceContentsSchema`.

These changes ensure stricter adherence to the intended data format, improving data integrity for binary content types.